### PR TITLE
Updated build.gradle id edu.wpi.first.GradleRIO vers. from 2023.4.2 to the 2023.4.3 version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id "java"
-    id "edu.wpi.first.GradleRIO" version "2023.4.2"
+    id "edu.wpi.first.GradleRIO" version "2023.4.3"
 }
 
 sourceCompatibility = JavaVersion.VERSION_11


### PR DESCRIPTION
No big deal.